### PR TITLE
Fix an issue that prevents setting a color to the same piece of text twice

### DIFF
--- a/eaem-64-extensions/eaem-touchui-dialog-rte-color-picker/jcr_root/apps/eaem-touchui-dialog-rte-color-picker/clientlib/color-picker.js
+++ b/eaem-64-extensions/eaem-touchui-dialog-rte-color-picker/jcr_root/apps/eaem-touchui-dialog-rte-color-picker/clientlib/color-picker.js
@@ -212,8 +212,11 @@
             //remove existing color before adding new color
             if (tags != null) {
                 nodeList.removeNodesByTag(execDef.editContext, tagObj.tag, undefined, true);
+                // update common ancestor after node removal; otherwise, the ancestor would
+                // still be the removed node
+                nodeList.commonAncestor = nodeList.nodes[0].dom.parentNode;
             }
-
+        
             nodeList.surround(execDef.editContext, tagObj.tag, tagObj.attributes);
         }
     });


### PR DESCRIPTION
Before setting a color for the second time the previous <span> tag is removed. After that the selected text is sorrounded with a new <span> tag but RTE still thinks the selected text ancestor element is first the removed <span> tag.

AEM Version: Adobe Experience Manager (6.4.2.0)

WCM Core Components Version: 2.0.4 (https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.4)

Error: Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node


Steps to reproduce:

![bug-rte-color-picker](https://user-images.githubusercontent.com/1251059/51385044-320cd900-1b05-11e9-9b91-cc20649bb90d.gif)

